### PR TITLE
Truncate second fraction to 3 digits

### DIFF
--- a/test/Main.purs
+++ b/test/Main.purs
@@ -77,6 +77,14 @@ main = run [consoleReporter] do
                             unwrapISO iso `shouldEqual`
                                 mkDateTime 2018 DT.January 9 13 16 43 999
 
+                it "handles more than 3 digits second fraction" do
+                    case decodeISO "2018-01-09T13:16:43.1234Z" of
+                        Left err ->
+                            fail $ "decoding failed: " <> err
+                        Right iso ->
+                            show iso `shouldEqual`
+                                "2018-01-09T13:16:43.123Z"
+
             describe "malformed input" do  -- malformed as far as we're concerned...
 
                 it "fails if not YYYY MM DD" do


### PR DESCRIPTION
According to [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6), 

> time-secfrac    = "." 1*DIGIT

`time-secfrac` doesn't mean milliseconds.

In current master, `.1234` will be parsed as `999` milliseconds, which is incorrect.