### PR TITLE
Bump codec dependency version to 5.x line.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,21 +1,26 @@
 {
-    "name": "purescript-datetime-iso",
-    "homepage": "https://github.com/jmackie/purescript-datetime-iso",
-    "description": "PureScript library for easily serializing datetimes",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/jmackie/purescript-datetime-iso.git"
-    },
-    "ignore": ["**/.*", "node_modules", "bower_components", "output"],
-    "dependencies": {
-        "purescript-prelude": "^4.1.0",
-        "purescript-argonaut-codecs": "^4.0.2",
-        "purescript-datetime": "^4.0.0",
-        "purescript-parsing": "^5.0.1",
-        "purescript-newtype": "^3.0.0"
-    },
-    "devDependencies": {
-        "purescript-spec": "^3.0.0"
-    }
+  "name": "purescript-datetime-iso",
+  "homepage": "https://github.com/jmackie/purescript-datetime-iso",
+  "description": "PureScript library for easily serializing datetimes",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jmackie/purescript-datetime-iso.git"
+  },
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "output"
+  ],
+  "dependencies": {
+    "purescript-prelude": "^4.1.0",
+    "purescript-argonaut-codecs": "^5.1.0",
+    "purescript-datetime": "^4.0.0",
+    "purescript-parsing": "^5.0.1",
+    "purescript-newtype": "^3.0.0"
+  },
+  "devDependencies": {
+    "purescript-spec": "^3.0.0"
+  }
 }


### PR DESCRIPTION
I'm proposing a 3.x release line that is based on the new argonaut 5.

I specifically have a need for this as I am presently blocked from my own upgrade until this happens, or I re-implement/fork this library for myself.

This PR would provide the change.

There are actually no code changes needed, as the api remained stable for the purposes of this patch.