### PR TITLE
argonaut-codecs upgrade v7.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     },
     "ignore": ["**/.*", "node_modules", "bower_components", "output"],
     "dependencies": {
-        "purescript-argonaut-codecs": "^6.0.0",
+        "purescript-argonaut-codecs": "^7.0.0",
         "purescript-datetime": "^4.1.1",
         "purescript-parsing": "^5.0.3",
         "purescript-newtype": "^3.0.0"

--- a/src/Data/DateTime/ISO.purs
+++ b/src/Data/DateTime/ISO.purs
@@ -3,6 +3,7 @@ module Data.DateTime.ISO (ISO(..), unwrapISO) where
 import Prelude
 
 import Data.Argonaut.Decode (class DecodeJson, decodeJson)
+import Data.Argonaut.Decode.Error (JsonDecodeError(TypeMismatch))
 import Data.Argonaut.Encode (class EncodeJson, encodeJson)
 import Data.Array as Array
 import Data.Bifunctor (lmap)
@@ -71,7 +72,7 @@ removeTrailingZeros s =
 instance decodeJsonISO :: DecodeJson ISO where
     decodeJson = decodeJson
              >=> flip P.runParser (parseISO :: P.Parser String ISO)
-             >>> lmap P.parseErrorMessage
+             >>> lmap (P.parseErrorMessage >>> TypeMismatch)
 
 instance encodeJsonISO :: EncodeJson ISO where
     encodeJson = show >>> encodeJson


### PR DESCRIPTION
argonaut-codecs made a breaking change for their error type

```text
src/Data/DateTime/ISO.purs:57:18 - 59:42 (line 57, column 18 - line 59, column 42)

    Could not match type

      String

    with type

      JsonDecodeError
```